### PR TITLE
Update Serilog.Sinks.SQLite.csproj for missing reference

### DIFF
--- a/Serilog.Sinks.SQLite.csproj
+++ b/Serilog.Sinks.SQLite.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="1.1.14" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BugFix for Android Plattform (Xamarin): Included missing SQLitePCLRaw.core Nuget Reference like discussed here:
https://stackoverflow.com/questions/50746465/how-do-i-call-sqlitepcl-batteries-init

This fixed following error:
System.Exception: 'You need to call SQLitePCL.raw.SetProvider(). If you are using a bundle package, this is done by calling SQLitePCL.Batteries.Init().'